### PR TITLE
Fix battery sensor to align with new structure

### DIFF
--- a/custom_components/bouncie/__init__.py
+++ b/custom_components/bouncie/__init__.py
@@ -51,8 +51,8 @@ def patch_missing_data(vehicle_info):
             "milOn": "Not available",
             "lastUpdated": "Not available",
         }
-    elif "battery" not in vehicle_info["stats"]["mil"]:
-        vehicle_info["stats"]["mil"]["battery"] = {
+    elif "battery" not in vehicle_info["stats"]:
+        vehicle_info["stats"]["battery"] = {
             "status": "Not available",
             "lastUpdated": "Not available",
         }

--- a/custom_components/bouncie/sensor.py
+++ b/custom_components/bouncie/sensor.py
@@ -117,19 +117,17 @@ SENSORS: tuple[BouncieSensorEntityDescription, ...] = (
         value_fn=lambda vehicle_info: vehicle_info["stats"]["mil"]["milOn"],
         extra_attrs_fn=lambda vehicle_info: {
             const.ATTR_VEHICLE_MIL_LAST_UPDATED_KEY: vehicle_info["stats"]["mil"][
-                "lastUpdated"
-            ]
+                "lastUpdated"]
         },
     ),
     BouncieSensorEntityDescription(
         key="car-battery",
         icon="mdi:car-battery",
         name="Car Battery",
-        value_fn=lambda vehicle_info: vehicle_info["stats"]["mil"]["battery"]["status"],
+        value_fn=lambda vehicle_info: vehicle_info["stats"]["battery"]["status"],
         extra_attrs_fn=lambda vehicle_info: {
-            const.ATTR_VEHICLE_BATTERY_LAST_UPDATED_KEY: vehicle_info["stats"]["mil"][
-                "battery"
-            ]["lastUpdated"]
+            const.ATTR_VEHICLE_BATTERY_LAST_UPDATED_KEY: vehicle_info["stats"][
+                "battery"]["lastUpdated"]
         },
     ),
 )

--- a/tests/const.py
+++ b/tests/const.py
@@ -68,10 +68,10 @@ MOCK_VEHICLES_RESPONSE = [
             "mil": {
                 "milOn": False,
                 "lastUpdated": "2022-11-23T01:38:55.000Z",
-                "battery": {
-                    "status": "normal",
-                    "lastUpdated": "2022-11-23T01:37:41.000Z",
-                },
+            },
+            "battery": {
+                "status": "normal",
+                "lastUpdated": "2022-11-23T01:37:41.000Z",
             },
         },
     },
@@ -93,10 +93,10 @@ MOCK_VEHICLES_IMEI_RESPONSE = [
             "mil": {
                 "milOn": False,
                 "lastUpdated": "2020-01-01 12:00:00:000Z",
-                "battery": {
-                    "status": "normal",
-                    "lastUpdated": "2020-04-25 12:00:00:000Z",
-                },
+            },
+            "battery": {
+                "status": "normal",
+                "lastUpdated": "2020-04-25 12:00:00:000Z",
             },
         },
     }

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -102,7 +102,7 @@ async def test_car_battery_sensor(
     state = hass.states.get("sensor.my_prius_car_battery")
     assert (
         state.state
-        == const.MOCK_VEHICLES_RESPONSE[0]["stats"]["mil"]["battery"]["status"]
+        == const.MOCK_VEHICLES_RESPONSE[0]["stats"]["battery"]["status"]
     )
 
 
@@ -131,7 +131,7 @@ async def test_battery_info_missing(
 ) -> None:
     """Test battery info missing from bouncie server."""
     updated_response = list(const.MOCK_VEHICLES_RESPONSE)
-    del updated_response[0]["stats"]["mil"]["battery"]
+    del updated_response[0]["stats"]["battery"]
     await setup_platform(hass, SENSOR_DOMAIN, updated_response)
     entity_registry = er.async_get(hass)
     entry = entity_registry.async_get("sensor.my_prius_car_battery")


### PR DESCRIPTION
The battery sensor in HA has been broken for quite a while.  Upon investigation, the Vehicles API response has changed.  `battery` is no longer under `mil`.

Here is a current JSON payload from the API.

```
    {
      "model": { "make": "HONDA", "name": "Pilot", "year": 2019 },
      "nickName": "Pilot",
      "standardEngine": "3.5L V6",
      "vin": "8675309",
      "imei": "1234567890",
      "stats": {
        "localTimeZone": "-0600",
        "lastUpdated": "2024-12-08T22:34:01.000Z",
        "odometer": 3332,
        "location": {
          "lat": 123.000,
          "lon": -123.000,
          "heading": 36,
          "address": null
        },
        "fuelLevel": 86.4857712277679,
        "isRunning": false,
        "speed": 0,
        "mil": {
          "milOn": false,
          "lastUpdated": "2023-10-15T03:01:00.000Z",
          "qualifiedDtcList": []
        },
        "battery": {
          "status": "normal",
          "lastUpdated": "2024-12-01T22:34:44.000Z"
        }
      }
    }
```


This PR maps the sensor to the new JSON structure and updates the unit tests.