### PR TITLE
fix: resolve Home Assistant device tracker deprecations

### DIFF
--- a/custom_components/bouncie/device_tracker.py
+++ b/custom_components/bouncie/device_tracker.py
@@ -1,7 +1,6 @@
 """Support for Bouncie device tracker."""
 
-from homeassistant.components.device_tracker import SourceType
-from homeassistant.components.device_tracker.config_entry import TrackerEntity
+from homeassistant.components.device_tracker import SourceType, TrackerEntity
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -52,7 +51,7 @@ class BouncieVehicleTracker(
             manufacturer=self._vehicle_info[const.VEHICLE_MODEL_KEY]["make"],
             model=self._vehicle_info[const.VEHICLE_MODEL_KEY]["name"],
             name=vehicle_name,
-            hw_version=self._vehicle_info[const.VEHICLE_MODEL_KEY]["year"],
+            hw_version=str(self._vehicle_info[const.VEHICLE_MODEL_KEY]["year"]),
         )
         super().__init__(coordinator)
 

--- a/custom_components/bouncie/sensor.py
+++ b/custom_components/bouncie/sensor.py
@@ -188,7 +188,7 @@ class BouncieSensor(CoordinatorEntity[BouncieDataUpdateCoordinator], SensorEntit
             manufacturer=self._vehicle_info[const.VEHICLE_MODEL_KEY]["make"],
             model=self._vehicle_info[const.VEHICLE_MODEL_KEY]["name"],
             name=self._vehicle_info["nickName"],
-            hw_version=self._vehicle_info[const.VEHICLE_MODEL_KEY]["year"],
+            hw_version=str(self._vehicle_info[const.VEHICLE_MODEL_KEY]["year"]),
         )
         super().__init__(coordinator)
 

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -6,6 +6,7 @@ from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER_DOM
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 import homeassistant.util.dt as date_util
+from pytest import LogCaptureFixture
 from pytest_homeassistant_custom_component.common import async_fire_time_changed
 from pytest_homeassistant_custom_component.test_util.aiohttp import AiohttpClientMocker
 
@@ -13,7 +14,9 @@ from . import const, setup_platform
 
 
 async def test_device_tracker(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    caplog: LogCaptureFixture,
 ) -> None:
     """Test getting all vehicles."""
     await setup_platform(hass, DEVICE_TRACKER_DOMAIN)
@@ -35,6 +38,8 @@ async def test_device_tracker(
         state.attributes["heading"]
         == const.MOCK_VEHICLES_RESPONSE[0]["stats"]["location"]["heading"]
     )
+    assert "The deprecated alias TrackerEntity was used from bouncie" not in caplog.text
+    assert "passes a non-string value of type int as hw_version" not in caplog.text
 
 
 async def test_device_tracker_update(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -5,6 +5,7 @@ from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 import homeassistant.util.dt as date_util
+from pytest import LogCaptureFixture
 from pytest_homeassistant_custom_component.common import async_fire_time_changed
 from pytest_homeassistant_custom_component.test_util.aiohttp import AiohttpClientMocker
 
@@ -12,7 +13,9 @@ from . import const, setup_platform
 
 
 async def test_car_info_sensor(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    caplog: LogCaptureFixture,
 ) -> None:
     """Test getting all vehicles."""
     await setup_platform(hass, SENSOR_DOMAIN)
@@ -27,6 +30,7 @@ async def test_car_info_sensor(
     )
     assert state.attributes["vin"] == const.MOCK_VEHICLES_RESPONSE[0]["vin"]
     assert state.attributes["imei"] == const.MOCK_VEHICLES_RESPONSE[0]["imei"]
+    assert "passes a non-string value of type int as hw_version" not in caplog.text
 
 
 async def test_car_odometer_sensor(


### PR DESCRIPTION
Thanks to @cap60552 for the clear reports in #81 and #82.

This updates the integration to use Home Assistant's supported `TrackerEntity` import and ensures the vehicle model year is passed to the device registry as a string. The existing behaviour remains unchanged.

I've also added regression assertions covering both warnings.

### Testing

- Home Assistant 2026.7 focused regression tests: 2 passed
- Full project test suite: 28 passed
- Coverage: 100%
- `git diff --check`: passed

Fixes #81
Fixes #82
